### PR TITLE
Add caching for filtered books lists #19

### DIFF
--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -35,8 +35,9 @@ class BookController extends Controller
         // $books = $books->get();                           // Execute the query and retrieve the results
 
         // Caches the result of the `$books->get()` query for 3600 seconds (1 hour).
-        // $books = cache()->remember('books', 3600, fn() => $books->get());
-        $books = Cache::remember('books', 3600, fn() => $books->get());
+        $cacheKey = 'books:' . $filter . ':' . $title;
+        // $books = cache()->remember($cacheKey, 3600, fn() => $books->get());
+        $books = Cache::remember($cacheKey, 3600, fn() => $books->get());
 
         // Return the 'books.index' view and pass the $books variable to it for rendering.
         return view('books.index', ['books' => $books]);


### PR DESCRIPTION
Implement caching for each applied filter when retrieving books lists, optimizing performance by storing unique cached results for different filter combinations.