### PR TITLE
Add rate limiting for book reviews #34

### DIFF
--- a/app/Http/Controllers/ReviewController.php
+++ b/app/Http/Controllers/ReviewController.php
@@ -7,6 +7,12 @@ use App\Models\Book;
 
 class ReviewController extends Controller
 {
+
+    public function __construct()
+    {
+        $this->middleware('throttle:reviews')->only(['store']);
+    }
+
     /**
      * Show the form for creating a new resource.
      */

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -28,6 +28,10 @@ class RouteServiceProvider extends ServiceProvider
             return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
         });
 
+        RateLimiter::for('reviews', function (Request $request) {
+            return Limit::perHour(3)->by($request->user()?->id ?: $request->ip());
+        });
+
         $this->routes(function () {
             Route::middleware('api')
                 ->prefix('api')

--- a/resources/views/books/reviews/create.blade.php
+++ b/resources/views/books/reviews/create.blade.php
@@ -12,9 +12,7 @@
         type="text"
         name="review"
         required
-        class="input">
-    {{ isset($review) ? $review : old('review') }}
-    </textarea>
+        class="input">{{ isset($review) ? $review : old('review') }}</textarea>
 
     @error('review')
     <div class="text-red-600/100 font-normal text-xs mb-2">{{ $message }}</div>


### PR DESCRIPTION
Implement rate limiting mechanism in Laravel to restrict the frequency of submitting book reviews within a defined timeframe, preventing abuse and spam.